### PR TITLE
SCUBA-8: Uniform naming of "metricsClass"

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -23,7 +23,7 @@ export type ScubaClientParameters = Omit<
 export type ScubaMetrics = {
     objectsTotal: number;
     bytesTotal: number;
-    metricClass: string;
+    metricsClass: string;
     resourceName: string;
 };
 


### PR DESCRIPTION
Having both "metricsClass" and "metricClass" can cause confusion.

Went with "metricsClass" just before it has been used more time in the server code. 