### PR TITLE
SCUBA-177: Admin API improvements

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -189,21 +189,21 @@ export const ScubaApiAxiosParamCreator = function (configuration?: Configuration
         /**
          *
          * @param {AdminActions} action
-         * @param {string} recordLog
+         * @param {string} logId
          * @param {any} [body]
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         admin: async (
             action: AdminActions,
-            recordLog: string,
+            logId: string,
             body?: any,
             options: AxiosRequestConfig = {},
         ): Promise<RequestArgs> => {
             // verify required parameter 'action' is not null or undefined
             assertParamExists('admin', 'action', action);
-            // verify required parameter 'recordLog' is not null or undefined
-            assertParamExists('admin', 'recordLog', recordLog);
+            // verify required parameter 'logId' is not null or undefined
+            assertParamExists('admin', 'logId', logId);
 
             const localVarPath = '/admin';
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
@@ -215,7 +215,7 @@ export const ScubaApiAxiosParamCreator = function (configuration?: Configuration
 
             const localVarRequestOptions = { method: 'PUT', ...baseOptions, ...options };
             const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = { action, recordLog } as any;
+            const localVarQueryParameter = { action, logId } as any;
 
             localVarHeaderParameter['Content-Type'] = 'application/json';
 
@@ -303,18 +303,18 @@ export const ScubaApiFp = function (configuration?: Configuration) {
         /**
          *
          * @param {AdminActions} action
-         * @param {string} recordLog
+         * @param {string} logId
          * @param {any} [body]
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         async admin(
             action: AdminActions,
-            recordLog: string,
+            logId: string,
             body?: any,
             options?: AxiosRequestConfig,
         ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.admin(action, recordLog, body, options);
+            const localVarAxiosArgs = await localVarAxiosParamCreator.admin(action, logId, body, options);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
     };
@@ -363,13 +363,13 @@ export const ScubaApiFactory = function (configuration?: Configuration, basePath
         /**
          *
          * @param {AdminActions} action
-         * @param {string} recordLog
+         * @param {string} logId
          * @param {any} [body]
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        admin(action: AdminActions, recordLog: string, body?: any, options?: any): AxiosPromise<void> {
-            return localVarFp.admin(action, recordLog, body, options).then(request => request(axios, basePath));
+        admin(action: AdminActions, logId: string, body?: any, options?: any): AxiosPromise<void> {
+            return localVarFp.admin(action, logId, body, options).then(request => request(axios, basePath));
         },
     };
 };
@@ -433,14 +433,14 @@ export class ScubaApi extends BaseAPI {
     /**
      *
      * @param {AdminActions} action
-     * @param {string} recordLog
+     * @param {string} logId
      * @param {any} [body]
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
-    public admin(action: AdminActions, recordLog: string, body?: any, options?: AxiosRequestConfig) {
+    public admin(action: AdminActions, logId: string, body?: any, options?: AxiosRequestConfig) {
         return ScubaApiFp(this.configuration)
-            .admin(action, recordLog, body, options)
+            .admin(action, logId, body, options)
             .then(request => request(this.axios, this.basePath));
     }
 }

--- a/src/api.ts
+++ b/src/api.ts
@@ -189,21 +189,21 @@ export const ScubaApiAxiosParamCreator = function (configuration?: Configuration
         /**
          *
          * @param {AdminActions} action
-         * @param {string} logId
+         * @param {string} sessionId
          * @param {any} [body]
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         admin: async (
             action: AdminActions,
-            logId: string,
+            sessionId: string,
             body?: any,
             options: AxiosRequestConfig = {},
         ): Promise<RequestArgs> => {
             // verify required parameter 'action' is not null or undefined
             assertParamExists('admin', 'action', action);
-            // verify required parameter 'logId' is not null or undefined
-            assertParamExists('admin', 'logId', logId);
+            // verify required parameter 'sessionId' is not null or undefined
+            assertParamExists('admin', 'sessionId', sessionId);
 
             const localVarPath = '/admin';
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
@@ -215,7 +215,7 @@ export const ScubaApiAxiosParamCreator = function (configuration?: Configuration
 
             const localVarRequestOptions = { method: 'PUT', ...baseOptions, ...options };
             const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = { action, logId } as any;
+            const localVarQueryParameter = { action, sessionId } as any;
 
             localVarHeaderParameter['Content-Type'] = 'application/json';
 
@@ -303,18 +303,18 @@ export const ScubaApiFp = function (configuration?: Configuration) {
         /**
          *
          * @param {AdminActions} action
-         * @param {string} logId
+         * @param {string} sessionId
          * @param {any} [body]
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         async admin(
             action: AdminActions,
-            logId: string,
+            sessionId: string,
             body?: any,
             options?: AxiosRequestConfig,
         ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.admin(action, logId, body, options);
+            const localVarAxiosArgs = await localVarAxiosParamCreator.admin(action, sessionId, body, options);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
     };
@@ -363,13 +363,13 @@ export const ScubaApiFactory = function (configuration?: Configuration, basePath
         /**
          *
          * @param {AdminActions} action
-         * @param {string} logId
+         * @param {string} sessionId
          * @param {any} [body]
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        admin(action: AdminActions, logId: string, body?: any, options?: any): AxiosPromise<void> {
-            return localVarFp.admin(action, logId, body, options).then(request => request(axios, basePath));
+        admin(action: AdminActions, sessionId: string, body?: any, options?: any): AxiosPromise<void> {
+            return localVarFp.admin(action, sessionId, body, options).then(request => request(axios, basePath));
         },
     };
 };
@@ -433,14 +433,14 @@ export class ScubaApi extends BaseAPI {
     /**
      *
      * @param {AdminActions} action
-     * @param {string} logId
+     * @param {string} sessionId
      * @param {any} [body]
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
-    public admin(action: AdminActions, logId: string, body?: any, options?: AxiosRequestConfig) {
+    public admin(action: AdminActions, sessionId: string, body?: any, options?: AxiosRequestConfig) {
         return ScubaApiFp(this.configuration)
-            .admin(action, logId, body, options)
+            .admin(action, sessionId, body, options)
             .then(request => request(this.axios, this.basePath));
     }
 }

--- a/src/client.ts
+++ b/src/client.ts
@@ -170,8 +170,8 @@ export default class ScubaClient {
         return resp.data;
     }
 
-    async admin(action: AdminActions, recordLog: string, options?: AxiosRequestConfig, body?: any): Promise<void> {
-        const resp = (await this._api.admin(action, recordLog, body, {
+    async admin(action: AdminActions, logId: string, options?: AxiosRequestConfig, body?: any): Promise<void> {
+        const resp = (await this._api.admin(action, logId, body, {
             ...this._defaultReqOptions,
             ...options,
         })) as any;

--- a/src/client.ts
+++ b/src/client.ts
@@ -48,6 +48,11 @@ export type HealthCheckResponse = {
     date?: string;
 };
 
+export type AdminResponseCseq = {
+    logId: string;
+    cseq: number;
+};
+
 function lpad(num: number, digits: number) {
     return num.toString().padStart(digits, '0');
 }
@@ -170,7 +175,12 @@ export default class ScubaClient {
         return resp.data;
     }
 
-    async admin(action: AdminActions, logId: string, options?: AxiosRequestConfig, body?: any): Promise<void> {
+    async admin(
+        action: AdminActions,
+        logId: string,
+        options?: AxiosRequestConfig,
+        body?: any,
+    ): Promise<AdminResponseCseq | void> {
         const resp = (await this._api.admin(action, logId, body, {
             ...this._defaultReqOptions,
             ...options,

--- a/src/client.ts
+++ b/src/client.ts
@@ -49,7 +49,7 @@ export type HealthCheckResponse = {
 };
 
 export type AdminResponseCseq = {
-    logId: string;
+    sessionId: string;
     cseq: number;
 };
 
@@ -177,11 +177,11 @@ export default class ScubaClient {
 
     async admin(
         action: AdminActions,
-        logId: string,
+        sessionId: string,
         options?: AxiosRequestConfig,
         body?: any,
     ): Promise<AdminResponseCseq | void> {
-        const resp = (await this._api.admin(action, logId, body, {
+        const resp = (await this._api.admin(action, sessionId, body, {
             ...this._defaultReqOptions,
             ...options,
         })) as any;


### PR DESCRIPTION
1. Rename the admin API URL parameter `recordLog` to `logId` to be consistent with the API response.
2. Add a `AdminReadRaftCseq` response type