### PR TITLE
SCUBA-186: Add GetMetricsBatch API

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -47,6 +47,11 @@ export enum AdminActions {
  */
 export interface MetricsClass {}
 
+export type GetMetricsBatchBody = {
+    resourceNames: string[];
+    dates?: string[];
+};
+
 /**
  * ScubaApi - axios parameter creator
  * @export
@@ -127,6 +132,51 @@ export const ScubaApiAxiosParamCreator = function (configuration?: Configuration
                 .replace(`{${'metricsClass'}}`, encodeURIComponent(String(metricsClass)))
                 .replace(`{${'resourceName'}}`, encodeURIComponent(String(resourceName)))
                 .replace(`{${'metricsDate'}}`, encodeURIComponent(String(metricsDate)));
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options };
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            localVarHeaderParameter['Content-Type'] = 'application/json';
+
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {
+                ...localVarHeaderParameter,
+                ...headersFromBaseOptions,
+                ...options.headers,
+            };
+            localVarRequestOptions.data = serializeDataIfNeeded(body, localVarRequestOptions, configuration);
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         *
+         * @param {MetricsClass} metricsClass
+         * @param {GetMetricsBatchBody} body
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        getMetricsBatch: async (
+            metricsClass: MetricsClass,
+            body: GetMetricsBatchBody,
+            options: AxiosRequestConfig = {},
+        ): Promise<RequestArgs> => {
+            // verify required parameter 'metricsClass' is not null or undefined
+            assertParamExists('getMetricsBatch', 'metricsClass', metricsClass);
+            const localVarPath = `/metrics/{metricsClass}`.replace(
+                `{${'metricsClass'}}`,
+                encodeURIComponent(String(metricsClass)),
+            );
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -291,6 +341,21 @@ export const ScubaApiFp = function (configuration?: Configuration) {
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
+         *
+         * @param {MetricsClass} metricsClass
+         * @param {GetMetricsBatchBody} body
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async getMetricsBatch(
+            metricsClass: MetricsClass,
+            body: GetMetricsBatchBody,
+            options?: AxiosRequestConfig,
+        ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.getMetricsBatch(metricsClass, body, options);
+            return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
+        },
+        /**
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
@@ -415,6 +480,20 @@ export class ScubaApi extends BaseAPI {
     ) {
         return ScubaApiFp(this.configuration)
             .getMetrics(metricsClass, resourceName, metricsDate, body, options)
+            .then(request => request(this.axios, this.basePath));
+    }
+
+    /**
+     *
+     * @param {MetricsClass} metricsClass
+     * @param {GetMetricsBatchBody} body
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof ScubaApi
+     */
+    public getMetricsBatch(metricsClass: MetricsClass, body: GetMetricsBatchBody, options?: AxiosRequestConfig) {
+        return ScubaApiFp(this.configuration)
+            .getMetricsBatch(metricsClass, body, options)
             .then(request => request(this.axios, this.basePath));
     }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -6,7 +6,7 @@ import globalAxios, { AxiosRequestConfig, AxiosInstance, AxiosHeaders } from 'ax
 import { Sha256 } from '@aws-crypto/sha256-js';
 import { URL } from 'url';
 import { parse as parseQuerystring } from 'querystring';
-import { ScubaApi, AdminActions } from './api';
+import { ScubaApi, AdminActions, GetMetricsBatchBody } from './api';
 import { Configuration, ConfigurationParameters } from './configuration';
 
 export type MetricsClass = 'account' | 'bucket' | 'service';
@@ -51,6 +51,44 @@ export type HealthCheckResponse = {
 export type AdminResponseCseq = {
     sessionId: string;
     cseq: number;
+};
+
+export type ScubaHttpError = {
+    code: number;
+    description: string;
+};
+
+export type GetMetricsBatchResponseDateMetrics = {
+    date: string;
+    bytesTotal: number;
+    objectsTotal: number;
+};
+
+export type GetMetricsBatchResponseDateError = {
+    date: string;
+    error: ScubaHttpError;
+};
+
+export type GetMetricsBatchResponseDate = GetMetricsBatchResponseDateMetrics | GetMetricsBatchResponseDateError;
+
+export type GetMetricsBatchResponseResourceMetrics = {
+    metricsClass: MetricsClass;
+    resourceName: string;
+    metrics: GetMetricsBatchResponseDate[];
+};
+
+export type GetMetricsBatchResponseResourceError = {
+    metricsClass: MetricsClass;
+    resourceName: string;
+    error: ScubaHttpError;
+};
+
+export type GetMetricsBatchResponseResource =
+    | GetMetricsBatchResponseResourceMetrics
+    | GetMetricsBatchResponseResourceError;
+
+export type GetMetricsBatchResponse = {
+    metrics: GetMetricsBatchResponseResource[];
 };
 
 function lpad(num: number, digits: number) {
@@ -164,6 +202,18 @@ export default class ScubaClient {
         const day = lpad(date.getUTCDate(), 2);
         const dateString = `${year}-${month}-${day}`;
         const resp = (await this._api.getMetrics(metricsClass, resourceName, dateString, body, {
+            ...this._defaultReqOptions,
+            ...options,
+        })) as any;
+        return resp.data;
+    }
+
+    async getMetricsBatch(
+        metricsClass: MetricsClass,
+        body: GetMetricsBatchBody,
+        options?: AxiosRequestConfig,
+    ): Promise<GetMetricsBatchResponse> {
+        const resp = (await this._api.getMetricsBatch(metricsClass, body, {
             ...this._defaultReqOptions,
             ...options,
         })) as any;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
 export * from './client';
 export { default as ScubaClient } from './client';
-export { AdminActions } from './api';
+export { AdminActions, GetMetricsBatchBody } from './api';


### PR DESCRIPTION
Add the GetMetricsBatch API.

Tests in https://github.com/scality/scubaclient/pull/28

[SCUBA-178]: https://scality.atlassian.net/browse/SCUBA-178?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ